### PR TITLE
Fix node kinds exceeding OpenGraph schema maximum of three (#9)

### DIFF
--- a/node/Node.go
+++ b/node/Node.go
@@ -10,18 +10,29 @@ import (
 // Follows BloodHound OpenGraph schema requirements with unique IDs, kinds, and properties.
 //
 // Sources:
-// - https://bloodhound.specterops.io/opengraph/schema#nodes
-// - https://bloodhound.specterops.io/opengraph/schema#minimal-working-json
+// - https://bloodhound.specterops.io/opengraph/developer/nodes
+// - https://bloodhound.specterops.io/opengraph/developer/graph-data
 type Node struct {
 	id         string
 	kinds      []string
 	properties *properties.Properties
 }
 
+// MaxKinds is the maximum number of kinds a node may have, as defined by the
+// BloodHound OpenGraph schema (the node "kinds" array is constrained to
+// "maxItems": 3).
+//
+// Source: https://bloodhound.specterops.io/opengraph/developer/nodes
+const MaxKinds = 3
+
 // NewNode creates a new Node instance
 func NewNode(id string, kinds []string, p *properties.Properties) (*Node, error) {
 	if id == "" {
 		return nil, fmt.Errorf("node ID cannot be empty")
+	}
+
+	if len(kinds) > MaxKinds {
+		return nil, fmt.Errorf("node cannot have more than %d kinds, got %d", MaxKinds, len(kinds))
 	}
 
 	if kinds == nil {
@@ -39,11 +50,21 @@ func NewNode(id string, kinds []string, p *properties.Properties) (*Node, error)
 	}, nil
 }
 
-// AddKind adds a kind/type to the node if it doesn't already exist
-func (n *Node) AddKind(kind string) {
-	if !n.HasKind(kind) {
-		n.kinds = append(n.kinds, kind)
+// AddKind adds a kind/type to the node if it doesn't already exist.
+//
+// The BloodHound OpenGraph schema limits a node to at most MaxKinds (3) kinds.
+// AddKind returns true if the node has the kind after the call (it was added or
+// was already present) and false if the kind could not be added because the
+// node already holds the maximum number of kinds.
+func (n *Node) AddKind(kind string) bool {
+	if n.HasKind(kind) {
+		return true
 	}
+	if len(n.kinds) >= MaxKinds {
+		return false
+	}
+	n.kinds = append(n.kinds, kind)
+	return true
 }
 
 // RemoveKind removes a kind/type from the node if it exists

--- a/node/Node_test.go
+++ b/node/Node_test.go
@@ -194,6 +194,42 @@ func TestNodeString(t *testing.T) {
 	}
 }
 
+func TestNewNodeKindsLimit(t *testing.T) {
+	// Three kinds is the maximum allowed by the OpenGraph schema.
+	if _, err := node.NewNode("node1", []string{"A", "B", "C"}, nil); err != nil {
+		t.Fatalf("unexpected error for three kinds: %v", err)
+	}
+
+	// Four kinds must be rejected.
+	_, err := node.NewNode("node1", []string{"A", "B", "C", "D"}, nil)
+	if err == nil {
+		t.Fatal("expected error for a node created with four kinds, got nil")
+	}
+}
+
+func TestAddKindRespectsMaxKinds(t *testing.T) {
+	n, err := node.NewNode("node1", []string{"A", "B", "C"}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Adding a kind already present is a no-op success.
+	if !n.AddKind("A") {
+		t.Error("expected AddKind to return true for an existing kind")
+	}
+
+	// Adding a fourth distinct kind must fail and must not grow the slice.
+	if n.AddKind("D") {
+		t.Error("expected AddKind to return false when the node already has the maximum number of kinds")
+	}
+	if n.HasKind("D") {
+		t.Error("expected kind 'D' not to be added beyond the maximum")
+	}
+	if len(n.GetKinds()) != node.MaxKinds {
+		t.Errorf("expected %d kinds, got %d", node.MaxKinds, len(n.GetKinds()))
+	}
+}
+
 // Helper function to check if a slice contains a string
 func contains(slice []string, str string) bool {
 	for _, s := range slice {


### PR DESCRIPTION
### Linked Issue
Closes #9

### Root Cause
The BloodHound OpenGraph schema constrains each node's `kinds` array to `"maxItems": 3`, but that limit was never represented in the code. `NewNode` accepted any number of kinds, `AddKind` appended unconditionally, and `OpenGraph.AddNode` automatically appends `source_kind` to every node. A node created with three kinds therefore became a four-kind node once added to a graph with a source kind, and `ExportJSON` serialized it as-is — producing a payload BloodHound rejects on ingestion.

### Fix Description
- Add an exported `node.MaxKinds = 3` constant documenting the schema limit as the single source of truth.
- `NewNode` now returns an error when constructed with more than three kinds, surfacing invalid input at the boundary instead of emitting an invalid payload later.
- `AddKind` now returns a `bool`: `true` if the node has the kind after the call (added or already present), `false` if it could not be added because the node is already at the maximum. This caps the array without silently corrupting it.
- `OpenGraph.AddNode`'s existing `source_kind` injection now naturally stops at the cap. When a node already holds three kinds, the source kind is not added to its `kinds` array; the `metadata.source_kind` field written by `ExportJSON` still registers it at ingestion.

Changing `AddKind` from `func(string)` to `func(string) bool` is source-compatible: existing call sites use it as a statement and continue to compile.

### How Verified
- `go build ./...`, `go vet ./...`, and `go test ./...` all pass.
- New tests assert: `NewNode` errors on four kinds and succeeds on three; `AddKind` returns `true` for an existing kind, returns `false` for a fourth distinct kind, and does not grow the slice past `MaxKinds`.

### Test Coverage
**Added:** `node/Node_test.go` — `TestNewNodeKindsLimit`, `TestAddKindRespectsMaxKinds`.

### Scope of Change
- **Files changed:** `node/Node.go`, `node/Node_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low blast radius, local to node construction. `NewNode` now rejects >3 kinds and `AddKind` no longer appends past three — both are corrections toward schema conformance. Collectors that previously relied on emitting more than three kinds (already invalid) will now get an error or a capped array.