### PR TITLE
Fix property validation accepting null and non-primitive arrays (#11)

### DIFF
--- a/properties/Properties.go
+++ b/properties/Properties.go
@@ -70,21 +70,66 @@ func (p *Properties) Clear() {
 	p.Properties = make(map[string]interface{})
 }
 
-// isValidPropertyValue checks if a value is a valid property type
+// IsPropertyValueValid reports whether value is a valid OpenGraph property value.
+//
+// The BloodHound OpenGraph schema restricts a property value to a single
+// primitive (string, number, or boolean) or a homogeneous array of primitives.
+// null values, nested objects, arrays of objects, and arrays mixing primitive
+// types are not valid.
+//
+// Source: https://bloodhound.specterops.io/opengraph/developer/nodes
 func (p *Properties) IsPropertyValueValid(value interface{}) bool {
 	if value == nil {
-		return true
-	}
-
-	valueType := reflect.TypeOf(value)
-	switch valueType.Kind() {
-	case reflect.String, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
-		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
-		reflect.Float32, reflect.Float64, reflect.Bool, reflect.Slice:
-		return true
-	default:
 		return false
 	}
+
+	switch reflect.TypeOf(value).Kind() {
+	case reflect.Slice, reflect.Array:
+		return isHomogeneousPrimitiveSequence(reflect.ValueOf(value))
+	default:
+		return primitiveCategory(value) != ""
+	}
+}
+
+// primitiveCategory classifies value into one of the OpenGraph primitive
+// categories ("string", "number", "boolean"). It returns "" when value is nil
+// or not a primitive (e.g. an object, slice, or array).
+func primitiveCategory(value interface{}) string {
+	if value == nil {
+		return ""
+	}
+
+	switch reflect.TypeOf(value).Kind() {
+	case reflect.String:
+		return "string"
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		return "number"
+	case reflect.Bool:
+		return "boolean"
+	default:
+		return ""
+	}
+}
+
+// isHomogeneousPrimitiveSequence reports whether v is a slice or array whose
+// elements are all primitives belonging to the same OpenGraph category. An
+// empty sequence is considered valid.
+func isHomogeneousPrimitiveSequence(v reflect.Value) bool {
+	category := ""
+	for i := 0; i < v.Len(); i++ {
+		c := primitiveCategory(v.Index(i).Interface())
+		if c == "" {
+			return false
+		}
+		if category == "" {
+			category = c
+		} else if c != category {
+			return false
+		}
+	}
+	return true
 }
 
 // ToDict converts properties to map for JSON serialization

--- a/properties/Properties_test.go
+++ b/properties/Properties_test.go
@@ -46,8 +46,8 @@ func TestSetProperty(t *testing.T) {
 		{"int", 42},
 		{"float", 3.14},
 		{"bool", true},
-		{"nil", nil},
-		{"slice", []string{"a", "b", "c"}},
+		{"string-slice", []string{"a", "b", "c"}},
+		{"int-slice", []int{1, 2, 3}},
 	}
 
 	for _, test := range validTests {
@@ -69,9 +69,12 @@ func TestSetProperty(t *testing.T) {
 
 	// Test invalid property types (should panic)
 	invalidTests := []interface{}{
-		map[string]string{"key": "value"}, // map
-		struct{}{},                        // struct
-		func() {},                         // function
+		nil,                                   // null is not an allowed property value
+		map[string]string{"key": "value"},     // map / nested object
+		struct{}{},                            // struct
+		func() {},                             // function
+		[]map[string]string{{"key": "value"}}, // array of objects
+		[]interface{}{1, "a"},                 // array mixing primitive types
 	}
 
 	for _, invalidValue := range invalidTests {
@@ -260,9 +263,10 @@ func TestIsValidPropertyValue(t *testing.T) {
 		42,
 		3.14,
 		true,
-		nil,
 		[]string{"a", "b"},
 		[]int{1, 2, 3},
+		[]bool{true, false},
+		[]string{}, // empty homogeneous array
 	}
 
 	for _, value := range validTypes {
@@ -273,10 +277,14 @@ func TestIsValidPropertyValue(t *testing.T) {
 
 	// Test invalid types
 	invalidTypes := []interface{}{
-		map[string]string{"key": "value"},
+		nil,                               // null is not an allowed property value
+		map[string]string{"key": "value"}, // nested object
 		struct{ field string }{field: "value"},
 		func() {},
 		make(chan int),
+		[]map[string]string{{"key": "value"}}, // array of objects
+		[]interface{}{1, "a"},                 // array mixing primitive types
+		[][]int{{1, 2}},                       // array of arrays
 	}
 
 	for _, value := range invalidTypes {


### PR DESCRIPTION
### Linked Issue
Closes #11

### Root Cause
The OpenGraph node schema restricts a property value to a single primitive (string, number, or boolean) or a homogeneous array of primitives; `null`, nested objects, arrays of objects, and arrays mixing primitive types are not allowed. `IsPropertyValueValid` predated those constraints: it returned `true` for `nil`, and its `reflect.Slice` case approved any slice purely by container kind, never inspecting element types or checking homogeneity. As a result `SetProperty` would store `null`, `[]map[string]any{...}`, and mixed `[]interface{}{...}` values that are serialized into payloads BloodHound rejects at ingestion.

### Fix Description
`IsPropertyValueValid` now:
- rejects `nil` (`null` is not a valid value),
- accepts a value only if it is a primitive (string, number, boolean), and
- accepts a slice/array only if every element is a primitive and all elements share the same primitive category (string / number / boolean); empty sequences remain valid.

Element classification and homogeneity are factored into two small helpers (`primitiveCategory`, `isHomogeneousPrimitiveSequence`) so the rule reads directly off the schema's `anyOf` of primitive/array types. The existing `SetProperty` contract (panic on an invalid value) is unchanged — only the definition of "valid" is corrected.

### How Verified
- `go build ./...`, `go vet ./...`, and `go test ./...` all pass.
- Tests assert validity for primitives and homogeneous arrays (`[]string`, `[]int`, `[]bool`, empty array) and invalidity for `nil`, maps/structs/funcs/channels, arrays of objects, arrays mixing primitive types, and arrays of arrays. The `SetProperty` panic path is exercised for each newly-invalid value.

### Test Coverage
**Added / updated:** `properties/Properties_test.go` — `TestIsValidPropertyValue` and `TestSetProperty` extended with homogeneous-array valid cases and `nil` / array-of-objects / mixed-array / nested-array invalid cases; the previously-valid `nil` case was moved to the invalid set to match the schema.

### Scope of Change
- **Files changed:** `properties/Properties.go`, `properties/Properties_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low and local to value validation. `SetProperty(k, nil)` now panics like other invalid values (previously it stored `null`). Note the pre-existing interaction with import: `NewPropertiesFromMap` — used by `FromJSON` — calls `SetProperty`, so a `null` property value in imported JSON now triggers the same panic that nested-object values already trigger today; making the import path tolerant of schema-invalid values is a separate concern and is not changed here.