### PR TITLE
Add edge endpoint match_by strategies: id, name, property (#13)

### DIFF
--- a/OpenGraph.go
+++ b/OpenGraph.go
@@ -49,23 +49,31 @@ func NewOpenGraph(sourceKind string) *OpenGraph {
 //
 //	bool: True if the edge was successfully added, false if validation failed
 //	      (e.g., nodes do not exist or the edge is a duplicate).
-func (g *OpenGraph) AddEdge(edge *edge.Edge) bool {
-	// Verify both nodes exist
-	if _, exists := g.nodes[edge.GetStartNodeID()]; !exists {
-		return false
+func (g *OpenGraph) AddEdge(e *edge.Edge) bool {
+	// Verify both endpoints exist, but only for endpoints resolved by node id.
+	// name- and property-matched endpoints are resolved by BloodHound at
+	// ingestion time and cannot be validated against the local node set.
+	start := e.GetStart()
+	if start.GetMatchBy() == edge.MatchByID {
+		if _, exists := g.nodes[start.GetValue()]; !exists {
+			return false
+		}
 	}
-	if _, exists := g.nodes[edge.GetEndNodeID()]; !exists {
-		return false
-	}
-
-	// Check for duplicate edge
-	for _, e := range g.edges {
-		if e.Equal(edge) {
+	end := e.GetEnd()
+	if end.GetMatchBy() == edge.MatchByID {
+		if _, exists := g.nodes[end.GetValue()]; !exists {
 			return false
 		}
 	}
 
-	return g.AddEdgeWithoutValidation(edge)
+	// Check for duplicate edge
+	for _, existing := range g.edges {
+		if existing.Equal(e) {
+			return false
+		}
+	}
+
+	return g.AddEdgeWithoutValidation(e)
 }
 
 // AddEdgeWithoutValidation adds an edge to the graph without validating the nodes.
@@ -488,15 +496,22 @@ func (g *OpenGraph) GetConnectedComponents() []map[string]bool {
 func (g *OpenGraph) ValidateGraph() []string {
 	var errors []string
 
-	// Check for orphaned edges
-	for _, edge := range g.edges {
-		if _, exists := g.nodes[edge.GetStartNodeID()]; !exists {
-			errors = append(errors, fmt.Sprintf("Edge %s references non-existent start node: %s",
-				edge.GetKind(), edge.GetStartNodeID()))
+	// Check for orphaned edges. Only id-matched endpoints reference local nodes;
+	// name- and property-matched endpoints are resolved at ingestion time.
+	for _, e := range g.edges {
+		start := e.GetStart()
+		if start.GetMatchBy() == edge.MatchByID {
+			if _, exists := g.nodes[start.GetValue()]; !exists {
+				errors = append(errors, fmt.Sprintf("Edge %s references non-existent start node: %s",
+					e.GetKind(), start.GetValue()))
+			}
 		}
-		if _, exists := g.nodes[edge.GetEndNodeID()]; !exists {
-			errors = append(errors, fmt.Sprintf("Edge %s references non-existent end node: %s",
-				edge.GetKind(), edge.GetEndNodeID()))
+		end := e.GetEnd()
+		if end.GetMatchBy() == edge.MatchByID {
+			if _, exists := g.nodes[end.GetValue()]; !exists {
+				errors = append(errors, fmt.Sprintf("Edge %s references non-existent end node: %s",
+					e.GetKind(), end.GetValue()))
+			}
 		}
 	}
 
@@ -612,15 +627,45 @@ func (g *OpenGraph) FromJSON(jsonData string) error {
 		Kinds      []string               `json:"kinds"`
 		Properties map[string]interface{} `json:"properties"`
 	}
+	type propertyMatcher struct {
+		Key      string      `json:"key"`
+		Operator string      `json:"operator"`
+		Value    interface{} `json:"value"`
+	}
 	type endpoint struct {
-		Value   string `json:"value"`
-		MatchBy string `json:"match_by"`
+		Value            string            `json:"value"`
+		MatchBy          string            `json:"match_by"`
+		Kind             string            `json:"kind"`
+		PropertyMatchers []propertyMatcher `json:"property_matchers"`
 	}
 	type ogEdge struct {
 		Kind       string                 `json:"kind"`
 		Start      endpoint               `json:"start"`
 		End        endpoint               `json:"end"`
 		Properties map[string]interface{} `json:"properties"`
+	}
+
+	// buildEndpoint converts a decoded endpoint into an edge.Endpoint, defaulting
+	// to id matching when match_by is omitted.
+	buildEndpoint := func(ep endpoint) (edge.Endpoint, error) {
+		matchBy := ep.MatchBy
+		if matchBy == "" {
+			matchBy = edge.MatchByID
+		}
+		switch matchBy {
+		case edge.MatchByID:
+			return edge.NewEndpointByID(ep.Value), nil
+		case edge.MatchByName:
+			return edge.NewEndpointByName(ep.Value, ep.Kind), nil
+		case edge.MatchByProperty:
+			matchers := make([]edge.PropertyMatcher, 0, len(ep.PropertyMatchers))
+			for _, m := range ep.PropertyMatchers {
+				matchers = append(matchers, edge.PropertyMatcher{Key: m.Key, Operator: m.Operator, Value: m.Value})
+			}
+			return edge.NewEndpointByProperty(matchers, ep.Kind), nil
+		default:
+			return edge.Endpoint{}, fmt.Errorf("unsupported match_by '%s'", ep.MatchBy)
+		}
 	}
 	type ogGraph struct {
 		Nodes []ogNode `json:"nodes"`
@@ -661,12 +706,13 @@ func (g *OpenGraph) FromJSON(jsonData string) error {
 
 	// Then import edges
 	for _, e := range openGraphDocument.Graph.Edges {
-		// Only 'id' is supported for match_by
-		if e.Start.MatchBy != "" && e.Start.MatchBy != "id" {
-			return fmt.Errorf("unsupported start.match_by '%s' for edge kind '%s'", e.Start.MatchBy, e.Kind)
+		startEndpoint, err := buildEndpoint(e.Start)
+		if err != nil {
+			return fmt.Errorf("invalid start endpoint for edge kind '%s': %w", e.Kind, err)
 		}
-		if e.End.MatchBy != "" && e.End.MatchBy != "id" {
-			return fmt.Errorf("unsupported end.match_by '%s' for edge kind '%s'", e.End.MatchBy, e.Kind)
+		endEndpoint, err := buildEndpoint(e.End)
+		if err != nil {
+			return fmt.Errorf("invalid end endpoint for edge kind '%s': %w", e.Kind, err)
 		}
 
 		var props *properties.Properties
@@ -676,11 +722,11 @@ func (g *OpenGraph) FromJSON(jsonData string) error {
 			props = properties.NewProperties()
 		}
 
-		newEdge, err := edge.NewEdge(e.Start.Value, e.End.Value, e.Kind, props)
+		newEdge, err := edge.NewEdgeWithEndpoints(startEndpoint, endEndpoint, e.Kind, props)
 		if err != nil {
-			return fmt.Errorf("invalid edge (%s -> %s, kind '%s'): %w", e.Start.Value, e.End.Value, e.Kind, err)
+			return fmt.Errorf("invalid edge (kind '%s'): %w", e.Kind, err)
 		}
-		// Append semantics: skip duplicates and require nodes to exist
+		// Append semantics: skip duplicates and require id-matched nodes to exist
 		_ = g.AddEdge(newEdge)
 	}
 

--- a/OpenGraph_test.go
+++ b/OpenGraph_test.go
@@ -89,6 +89,59 @@ func TestExportJSON(t *testing.T) {
 	})
 }
 
+func TestFromJSONPropertyMatching(t *testing.T) {
+	jsonData := `{
+  "graph": {
+    "nodes": [
+      { "id": "server-1", "kinds": ["Server"], "properties": { "name": "SRV1" } }
+    ],
+    "edges": [
+      {
+        "kind": "CustomRelationship",
+        "start": {
+          "match_by": "property",
+          "property_matchers": [ { "key": "username", "operator": "equals", "value": "alice.smith" } ],
+          "kind": "User"
+        },
+        "end": { "match_by": "id", "value": "server-1" }
+      }
+    ]
+  }
+}`
+
+	g := gopengraph.NewOpenGraph("")
+	if err := g.FromJSON(jsonData); err != nil {
+		t.Fatalf("FromJSON failed: %v", err)
+	}
+
+	// The property-matched edge must be imported even though its start endpoint
+	// does not correspond to a local node.
+	if g.GetEdgeCount() != 1 {
+		t.Fatalf("expected 1 edge, got %d", g.GetEdgeCount())
+	}
+
+	edges := g.GetEdgesByKind("CustomRelationship")
+	if len(edges) != 1 {
+		t.Fatalf("expected 1 CustomRelationship edge, got %d", len(edges))
+	}
+	start := edges[0].GetStart()
+	if start.GetMatchBy() != edge.MatchByProperty {
+		t.Errorf("expected start match_by %q, got %q", edge.MatchByProperty, start.GetMatchBy())
+	}
+	matchers := start.GetPropertyMatchers()
+	if len(matchers) != 1 || matchers[0].Key != "username" || matchers[0].Value != "alice.smith" {
+		t.Errorf("unexpected property matchers: %v", matchers)
+	}
+
+	// A graph holding only id-matched and property-matched endpoints must not
+	// report the property endpoint as an orphan reference.
+	for _, errMsg := range g.ValidateGraph() {
+		if errMsg != "" && len(errMsg) >= 4 && errMsg[:4] == "Edge" {
+			t.Errorf("unexpected orphan-edge validation error: %s", errMsg)
+		}
+	}
+}
+
 func TestNewOpenGraph(t *testing.T) {
 	g := gopengraph.NewOpenGraph("test")
 	if g == nil {

--- a/edge/Edge.go
+++ b/edge/Edge.go
@@ -6,21 +6,161 @@ import (
 	"github.com/TheManticoreProject/gopengraph/properties"
 )
 
-// Edge represents a directed edge in the OpenGraph.
-// Follows BloodHound OpenGraph schema requirements with start/end nodes, kind, and properties.
-// All edges are directed and one-way as per BloodHound requirements.
+// match_by strategies for resolving an edge endpoint to a node, as defined by
+// the BloodHound OpenGraph edge schema.
 //
-// Sources:
-// - https://bloodhound.specterops.io/opengraph/schema#edges
-// - https://bloodhound.specterops.io/opengraph/schema#minimal-working-json
-type Edge struct {
-	startNodeID string
-	endNodeID   string
-	kind        string
-	properties  *properties.Properties
+// Source: https://bloodhound.specterops.io/opengraph/developer/edges
+const (
+	// MatchByID resolves an endpoint by unique node id. This is the default.
+	MatchByID = "id"
+	// MatchByName resolves an endpoint by name. Deprecated in BloodHound but
+	// still accepted; supported here so payloads using it can round-trip.
+	MatchByName = "name"
+	// MatchByProperty resolves an endpoint dynamically from one or more
+	// property matchers evaluated at ingestion time.
+	MatchByProperty = "property"
+)
+
+// PropertyMatcher is a single property-based match criterion, used when an
+// endpoint's match strategy is MatchByProperty. Values are restricted to
+// primitives (string, number, boolean) by the schema.
+type PropertyMatcher struct {
+	Key      string
+	Operator string
+	Value    interface{}
 }
 
-// NewEdge creates a new Edge instance
+// Endpoint identifies the start or end of an edge and describes how BloodHound
+// should resolve it to a node.
+type Endpoint struct {
+	matchBy          string
+	value            string
+	kind             string
+	propertyMatchers []PropertyMatcher
+}
+
+// NewEndpointByID creates an endpoint resolved by node id.
+func NewEndpointByID(value string) Endpoint {
+	return Endpoint{matchBy: MatchByID, value: value}
+}
+
+// NewEndpointByName creates an endpoint resolved by name. kind is optional and
+// may be empty; when set it disambiguates the kind of the target node.
+func NewEndpointByName(value string, kind string) Endpoint {
+	return Endpoint{matchBy: MatchByName, value: value, kind: kind}
+}
+
+// NewEndpointByProperty creates an endpoint resolved by property matchers. kind
+// is optional and may be empty.
+func NewEndpointByProperty(matchers []PropertyMatcher, kind string) Endpoint {
+	return Endpoint{matchBy: MatchByProperty, kind: kind, propertyMatchers: matchers}
+}
+
+// GetMatchBy returns the endpoint match strategy, defaulting to MatchByID when
+// unset.
+func (e Endpoint) GetMatchBy() string {
+	if e.matchBy == "" {
+		return MatchByID
+	}
+	return e.matchBy
+}
+
+// GetValue returns the endpoint value (the id or name). It is empty for
+// property-matched endpoints.
+func (e Endpoint) GetValue() string { return e.value }
+
+// GetKind returns the optional kind hint for the endpoint.
+func (e Endpoint) GetKind() string { return e.kind }
+
+// GetPropertyMatchers returns the property matchers for a property-matched
+// endpoint.
+func (e Endpoint) GetPropertyMatchers() []PropertyMatcher { return e.propertyMatchers }
+
+// Validate reports whether the endpoint is internally consistent with its match
+// strategy.
+func (e Endpoint) Validate() error {
+	switch e.GetMatchBy() {
+	case MatchByID, MatchByName:
+		if e.value == "" {
+			return fmt.Errorf("endpoint with match_by %q requires a non-empty value", e.GetMatchBy())
+		}
+	case MatchByProperty:
+		if len(e.propertyMatchers) == 0 {
+			return fmt.Errorf("endpoint with match_by %q requires at least one property matcher", MatchByProperty)
+		}
+		for _, m := range e.propertyMatchers {
+			if m.Key == "" {
+				return fmt.Errorf("property matcher requires a non-empty key")
+			}
+		}
+	default:
+		return fmt.Errorf("unsupported match_by %q", e.matchBy)
+	}
+	return nil
+}
+
+// ToDict converts the endpoint to a map for JSON serialization, matching the
+// shape expected by BloodHound for the endpoint's match strategy.
+func (e Endpoint) ToDict() map[string]interface{} {
+	dict := map[string]interface{}{
+		"match_by": e.GetMatchBy(),
+	}
+
+	if e.GetMatchBy() == MatchByProperty {
+		matchers := make([]map[string]interface{}, 0, len(e.propertyMatchers))
+		for _, m := range e.propertyMatchers {
+			matchers = append(matchers, map[string]interface{}{
+				"key":      m.Key,
+				"operator": m.Operator,
+				"value":    m.Value,
+			})
+		}
+		dict["property_matchers"] = matchers
+	} else {
+		dict["value"] = e.value
+	}
+
+	if e.kind != "" {
+		dict["kind"] = e.kind
+	}
+
+	return dict
+}
+
+// Equal reports whether two endpoints are equivalent.
+func (e Endpoint) Equal(other Endpoint) bool {
+	if e.GetMatchBy() != other.GetMatchBy() || e.value != other.value || e.kind != other.kind {
+		return false
+	}
+	if len(e.propertyMatchers) != len(other.propertyMatchers) {
+		return false
+	}
+	for i := range e.propertyMatchers {
+		if e.propertyMatchers[i] != other.propertyMatchers[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Edge represents a directed edge in the OpenGraph.
+// Follows BloodHound OpenGraph schema requirements with start/end endpoints,
+// kind, and properties. All edges are directed and one-way as per BloodHound
+// requirements.
+//
+// Sources:
+// - https://bloodhound.specterops.io/opengraph/developer/edges
+// - https://bloodhound.specterops.io/opengraph/developer/graph-data
+type Edge struct {
+	start      Endpoint
+	end        Endpoint
+	kind       string
+	properties *properties.Properties
+}
+
+// NewEdge creates a new Edge instance whose endpoints are resolved by node id.
+// This is the common case; use NewEdgeWithEndpoints for name or property
+// matching.
 func NewEdge(startNodeID string, endNodeID string, kind string, p *properties.Properties) (*Edge, error) {
 	if startNodeID == "" {
 		return nil, fmt.Errorf("start node ID cannot be empty")
@@ -28,8 +168,21 @@ func NewEdge(startNodeID string, endNodeID string, kind string, p *properties.Pr
 	if endNodeID == "" {
 		return nil, fmt.Errorf("end node ID cannot be empty")
 	}
+
+	return NewEdgeWithEndpoints(NewEndpointByID(startNodeID), NewEndpointByID(endNodeID), kind, p)
+}
+
+// NewEdgeWithEndpoints creates a new Edge instance from explicit endpoints,
+// allowing any match strategy for either end.
+func NewEdgeWithEndpoints(start Endpoint, end Endpoint, kind string, p *properties.Properties) (*Edge, error) {
 	if kind == "" {
 		return nil, fmt.Errorf("edge kind cannot be empty")
+	}
+	if err := start.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid start endpoint: %w", err)
+	}
+	if err := end.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid end endpoint: %w", err)
 	}
 
 	if p == nil {
@@ -37,10 +190,10 @@ func NewEdge(startNodeID string, endNodeID string, kind string, p *properties.Pr
 	}
 
 	return &Edge{
-		startNodeID: startNodeID,
-		endNodeID:   endNodeID,
-		kind:        kind,
-		properties:  p,
+		start:      start,
+		end:        end,
+		kind:       kind,
+		properties: p,
 	}, nil
 }
 
@@ -67,15 +220,9 @@ func (e *Edge) RemoveProperty(key string) {
 // ToDict converts edge to map for JSON serialization
 func (e *Edge) ToDict() map[string]interface{} {
 	edgeDict := map[string]interface{}{
-		"kind": e.kind,
-		"start": map[string]string{
-			"value":    e.startNodeID,
-			"match_by": "id",
-		},
-		"end": map[string]string{
-			"value":    e.endNodeID,
-			"match_by": "id",
-		},
+		"kind":  e.kind,
+		"start": e.start.ToDict(),
+		"end":   e.end.ToDict(),
 	}
 
 	// Only include properties if they exist and are not empty
@@ -86,14 +233,22 @@ func (e *Edge) ToDict() map[string]interface{} {
 	return edgeDict
 }
 
-// GetStartNodeID returns the start node ID
+// GetStart returns the start endpoint.
+func (e *Edge) GetStart() Endpoint { return e.start }
+
+// GetEnd returns the end endpoint.
+func (e *Edge) GetEnd() Endpoint { return e.end }
+
+// GetStartNodeID returns the start endpoint value. For id-matched endpoints this
+// is the node id; it is empty for property-matched endpoints.
 func (e *Edge) GetStartNodeID() string {
-	return e.startNodeID
+	return e.start.value
 }
 
-// GetEndNodeID returns the end node ID
+// GetEndNodeID returns the end endpoint value. For id-matched endpoints this is
+// the node id; it is empty for property-matched endpoints.
 func (e *Edge) GetEndNodeID() string {
-	return e.endNodeID
+	return e.end.value
 }
 
 // GetKind returns the edge kind/type
@@ -101,18 +256,18 @@ func (e *Edge) GetKind() string {
 	return e.kind
 }
 
-// Equal checks if two edges are equal based on their start, end, and kind
+// Equal checks if two edges are equal based on their endpoints and kind
 func (e *Edge) Equal(other *Edge) bool {
 	if other == nil {
 		return false
 	}
-	return e.startNodeID == other.startNodeID &&
-		e.endNodeID == other.endNodeID &&
-		e.kind == other.kind
+	return e.kind == other.kind &&
+		e.start.Equal(other.start) &&
+		e.end.Equal(other.end)
 }
 
 // String returns a string representation of the edge
 func (e *Edge) String() string {
 	return fmt.Sprintf("Edge(start='%s', end='%s', kind='%s', properties=%v)",
-		e.startNodeID, e.endNodeID, e.kind, e.properties.ToDict())
+		e.start.value, e.end.value, e.kind, e.properties.ToDict())
 }

--- a/edge/Edge_test.go
+++ b/edge/Edge_test.go
@@ -145,18 +145,18 @@ func TestEdgeToDict(t *testing.T) {
 	}
 
 	// Check start node
-	startNode, ok := dict["start"].(map[string]string)
+	startNode, ok := dict["start"].(map[string]interface{})
 	if !ok {
-		t.Fatal("expected start to be map[string]string")
+		t.Fatal("expected start to be map[string]interface{}")
 	}
 	if startNode["value"] != "start1" || startNode["match_by"] != "id" {
 		t.Error("incorrect start node mapping")
 	}
 
 	// Check end node
-	endNode, ok := dict["end"].(map[string]string)
+	endNode, ok := dict["end"].(map[string]interface{})
 	if !ok {
-		t.Fatal("expected end to be map[string]string")
+		t.Fatal("expected end to be map[string]interface{}")
 	}
 	if endNode["value"] != "end1" || endNode["match_by"] != "id" {
 		t.Error("incorrect end node mapping")
@@ -178,6 +178,102 @@ func TestEdgeString(t *testing.T) {
 	expected := "Edge(start='start1', end='end1', kind='CONNECTS_TO', properties=map[])"
 	if str != expected {
 		t.Errorf("expected string %q, got %q", expected, str)
+	}
+}
+
+func TestEdgeMatchByName(t *testing.T) {
+	e, err := edge.NewEdgeWithEndpoints(
+		edge.NewEndpointByName("alice", "User"),
+		edge.NewEndpointByName("file-server-1", "Server"),
+		"HasAccess",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	dict := e.ToDict()
+	start, ok := dict["start"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected start to be map[string]interface{}")
+	}
+	if start["match_by"] != edge.MatchByName {
+		t.Errorf("expected match_by %q, got %v", edge.MatchByName, start["match_by"])
+	}
+	if start["value"] != "alice" {
+		t.Errorf("expected value 'alice', got %v", start["value"])
+	}
+	if start["kind"] != "User" {
+		t.Errorf("expected kind 'User', got %v", start["kind"])
+	}
+	if _, present := start["property_matchers"]; present {
+		t.Error("name endpoint must not include property_matchers")
+	}
+}
+
+func TestEdgeMatchByProperty(t *testing.T) {
+	matchers := []edge.PropertyMatcher{
+		{Key: "username", Operator: "equals", Value: "alice.smith"},
+		{Key: "active", Operator: "equals", Value: true},
+	}
+	e, err := edge.NewEdgeWithEndpoints(
+		edge.NewEndpointByProperty(matchers, "User"),
+		edge.NewEndpointByID("server-1"),
+		"CustomRelationship",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	dict := e.ToDict()
+	start, ok := dict["start"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected start to be map[string]interface{}")
+	}
+	if start["match_by"] != edge.MatchByProperty {
+		t.Errorf("expected match_by %q, got %v", edge.MatchByProperty, start["match_by"])
+	}
+	if _, present := start["value"]; present {
+		t.Error("property endpoint must not include a top-level value")
+	}
+	pm, ok := start["property_matchers"].([]map[string]interface{})
+	if !ok {
+		t.Fatalf("expected property_matchers to be []map[string]interface{}, got %T", start["property_matchers"])
+	}
+	if len(pm) != 2 {
+		t.Fatalf("expected 2 property matchers, got %d", len(pm))
+	}
+	if pm[0]["key"] != "username" || pm[0]["operator"] != "equals" || pm[0]["value"] != "alice.smith" {
+		t.Errorf("unexpected first matcher: %v", pm[0])
+	}
+}
+
+func TestEndpointValidate(t *testing.T) {
+	// id/name require a value
+	if err := edge.NewEndpointByID("").Validate(); err == nil {
+		t.Error("expected error for id endpoint with empty value")
+	}
+	// property requires at least one matcher
+	if err := edge.NewEndpointByProperty(nil, "User").Validate(); err == nil {
+		t.Error("expected error for property endpoint without matchers")
+	}
+	// property matcher requires a key
+	bad := edge.NewEndpointByProperty([]edge.PropertyMatcher{{Operator: "equals", Value: "x"}}, "")
+	if err := bad.Validate(); err == nil {
+		t.Error("expected error for property matcher with empty key")
+	}
+	// valid endpoints
+	if err := edge.NewEndpointByName("alice", "User").Validate(); err != nil {
+		t.Errorf("unexpected error for valid name endpoint: %v", err)
+	}
+}
+
+func TestEdgeEqualAcrossMatchStrategies(t *testing.T) {
+	byID, _ := edge.NewEdge("a", "b", "K", nil)
+	byName, _ := edge.NewEdgeWithEndpoints(edge.NewEndpointByName("a", ""), edge.NewEndpointByID("b"), "K", nil)
+	if byID.Equal(byName) {
+		t.Error("edges differing only in start match strategy must not be equal")
 	}
 }
 


### PR DESCRIPTION
### Linked Issue
Closes #13

### Summary
Adds full support for the three OpenGraph edge endpoint resolution strategies — `id`, `name` (deprecated), and `property` (with `property_matchers`) — across the edge model, JSON export, and JSON import. Previously the library could only express id-matched endpoints and `FromJSON` rejected any other `match_by`.

### Design
- New `edge.Endpoint` value type captures `match_by`, `value`, optional `kind`, and `property_matchers`, with constructors `NewEndpointByID`, `NewEndpointByName`, and `NewEndpointByProperty`, plus a `Validate` method enforcing per-strategy requirements (id/name need a value; property needs at least one matcher with a non-empty key).
- New `edge.PropertyMatcher{Key, Operator, Value}` models a single matcher.
- `edge.Edge` now holds two `Endpoint`s instead of two raw id strings.
- `Endpoint.ToDict` serializes to the exact documented shape: `{match_by, value}` for id/name, `{match_by, property_matchers, kind?}` for property, omitting `value` in property mode and `kind` when unset.

### Backward Compatibility
- `NewEdge(startNodeID, endNodeID, kind, props)` is unchanged and now builds id endpoints; its error messages are preserved.
- `GetStartNodeID()` / `GetEndNodeID()` still return the endpoint value (the node id for id-matched edges). New `GetStart()` / `GetEnd()` expose the full endpoints.
- Wire format for id-matched edges is byte-identical; only the Go type of the `start`/`end` map in `ToDict` changed from `map[string]string` to `map[string]interface{}` (required to carry matchers).

### Graph operations
`OpenGraph.AddEdge` and `ValidateGraph` now apply node-existence checks only to id-matched endpoints; `name`/`property` endpoints are resolved by BloodHound at ingestion and cannot be validated locally, so they are accepted and are not flagged as orphan references. `FromJSON` decodes all three strategies (defaulting to `id` when `match_by` is omitted) and builds edges via the new `NewEdgeWithEndpoints`.

### How Verified
- `go build ./...`, `go vet ./...`, and `go test ./...` all pass.
- New tests:
  - `edge`: `TestEdgeMatchByName`, `TestEdgeMatchByProperty`, `TestEndpointValidate`, `TestEdgeEqualAcrossMatchStrategies`, and the updated `TestEdgeToDict`.
  - graph: `TestFromJSONPropertyMatching` imports a property-matched edge, asserts it is added despite having no local start node, and asserts `ValidateGraph` does not flag it as an orphan.
- The existing `TestJSONioInvolution` (id-matched round trip) continues to pass.

### Test Coverage
**Added:** see the tests listed above. **Updated:** `edge/Edge_test.go::TestEdgeToDict` for the new endpoint map type.

### Scope of Change
- **Files changed:** `edge/Edge.go`, `OpenGraph.go`, `edge/Edge_test.go`, `OpenGraph_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the feature:** none beyond the documented `ToDict` map-type change.

### Notes
`name`/`property` endpoints are not resolvable by the local id-based graph algorithms (`FindPaths`, `GetEdgesFromNode`, connected components); such edges simply do not participate in local traversal, which is expected since they are resolved server-side at ingestion.