### PR TITLE
Validate edge kind against OpenGraph schema pattern and reserved prefix (#15)

### DIFF
--- a/edge/Edge.go
+++ b/edge/Edge.go
@@ -2,9 +2,35 @@ package edge
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 
 	"github.com/TheManticoreProject/gopengraph/properties"
 )
+
+// edgeKindPattern is the set of characters the OpenGraph schema allows in an
+// edge kind: uppercase letters, lowercase letters, digits, and underscores.
+//
+// Source: https://bloodhound.specterops.io/opengraph/developer/edges
+var edgeKindPattern = regexp.MustCompile(`^[A-Za-z0-9_]+$`)
+
+// reservedKindPrefix is reserved by BloodHound in any letter case and must not
+// be used for custom edge kinds.
+const reservedKindPrefix = "tag_"
+
+// validateKind reports whether kind is a valid OpenGraph edge kind.
+func validateKind(kind string) error {
+	if kind == "" {
+		return fmt.Errorf("edge kind cannot be empty")
+	}
+	if !edgeKindPattern.MatchString(kind) {
+		return fmt.Errorf("edge kind %q must match %s", kind, edgeKindPattern.String())
+	}
+	if len(kind) >= len(reservedKindPrefix) && strings.EqualFold(kind[:len(reservedKindPrefix)], reservedKindPrefix) {
+		return fmt.Errorf("edge kind %q must not use the reserved %q prefix", kind, reservedKindPrefix)
+	}
+	return nil
+}
 
 // match_by strategies for resolving an edge endpoint to a node, as defined by
 // the BloodHound OpenGraph edge schema.
@@ -175,8 +201,8 @@ func NewEdge(startNodeID string, endNodeID string, kind string, p *properties.Pr
 // NewEdgeWithEndpoints creates a new Edge instance from explicit endpoints,
 // allowing any match strategy for either end.
 func NewEdgeWithEndpoints(start Endpoint, end Endpoint, kind string, p *properties.Properties) (*Edge, error) {
-	if kind == "" {
-		return nil, fmt.Errorf("edge kind cannot be empty")
+	if err := validateKind(kind); err != nil {
+		return nil, err
 	}
 	if err := start.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid start endpoint: %w", err)

--- a/edge/Edge_test.go
+++ b/edge/Edge_test.go
@@ -89,6 +89,32 @@ func TestNewEdge(t *testing.T) {
 	}
 }
 
+func TestNewEdgeKindValidation(t *testing.T) {
+	valid := []string{"Knows", "CONNECTS_TO", "Okta_ResetPassword", "a1_B2"}
+	for _, kind := range valid {
+		if _, err := edge.NewEdge("a", "b", kind, nil); err != nil {
+			t.Errorf("expected kind %q to be valid, got error: %v", kind, err)
+		}
+	}
+
+	invalid := []struct {
+		kind   string
+		reason string
+	}{
+		{"Has Access", "contains a space"},
+		{"Reset-Password", "contains a hyphen"},
+		{"Owns!", "contains punctuation"},
+		{"tag_custom", "reserved tag_ prefix"},
+		{"TAG_Custom", "reserved prefix, uppercase"},
+		{"Tag_Custom", "reserved prefix, mixed case"},
+	}
+	for _, tc := range invalid {
+		if _, err := edge.NewEdge("a", "b", tc.kind, nil); err == nil {
+			t.Errorf("expected kind %q to be rejected (%s), got nil error", tc.kind, tc.reason)
+		}
+	}
+}
+
 func TestEdgeProperties(t *testing.T) {
 	e, err := edge.NewEdge("start1", "end1", "CONNECTS_TO", nil)
 	if err != nil {


### PR DESCRIPTION
### Linked Issue
Closes #15

### Summary
`edge.NewEdge` now validates the edge `kind` against the OpenGraph edge schema instead of only checking that it is non-empty.

### Fix Description
Adds a `validateKind` helper, used by `NewEdge`, that rejects a kind which:
- is empty (unchanged behavior; same error message preserved),
- contains any character outside `^[A-Za-z0-9_]+$`, or
- begins with the reserved `tag_` prefix in any letter case (matched case-insensitively).

The allowed-character pattern is compiled once into a package-level `regexp`, and the reserved prefix is a named constant, so the rule reads directly off the documentation.

### How Verified
- `go build ./...`, `go vet ./...`, and `go test ./...` all pass.
- New `TestNewEdgeKindValidation` asserts acceptance of `Knows`, `CONNECTS_TO`, `Okta_ResetPassword`, `a1_B2` and rejection of kinds containing spaces, hyphens, or punctuation and of the `tag_` / `TAG_` / `Tag_` reserved prefix.
- Existing edge and graph tests (which use kinds such as `CONNECTS_TO`, `Knows`, `CustomRelationship`) continue to pass.

### Test Coverage
**Added:** `edge/Edge_test.go` — `TestNewEdgeKindValidation`.

### Scope of Change
- **Files changed:** `edge/Edge.go`, `edge/Edge_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low and local to edge construction. `NewEdge` now returns an error for kinds that were already invalid per the schema (and would have been rejected by BloodHound at ingestion).

### Notes
This touches the same `NewEdge` region as #14 (edge `match_by` strategies). Whichever merges first, the other needs a small rebase: in #14 the kind check moves into `NewEdgeWithEndpoints`, which is where this `validateKind` call should live after both land.