### PR TITLE
Update documentation links to the OpenGraph developer docs paths (#17)

### DIFF
--- a/OpenGraph.go
+++ b/OpenGraph.go
@@ -15,9 +15,8 @@ import (
 // Follows BloodHound OpenGraph schema requirements and best practices.
 //
 // Sources:
-// - https://bloodhound.specterops.io/opengraph/schema#opengraph
-// - https://bloodhound.specterops.io/opengraph/schema#minimal-working-json
-// - https://bloodhound.specterops.io/opengraph/best-practices
+// - https://bloodhound.specterops.io/opengraph/developer/graph-data
+// - https://bloodhound.specterops.io/opengraph/developer/best-practices
 type OpenGraph struct {
 	nodes      map[string]*node.Node
 	edges      []*edge.Edge

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@
 
 ## Features
 
-This module provides Go types and helpers for creating and managing graph structures that are compatible with BloodHound OpenGraph. The APIs follow the [BloodHound OpenGraph schema](https://bloodhound.specterops.io/opengraph/schema) and [best practices](https://bloodhound.specterops.io/opengraph/best-practices).
+This module provides Go types and helpers for creating and managing graph structures that are compatible with BloodHound OpenGraph. The APIs follow the [BloodHound OpenGraph schema](https://bloodhound.specterops.io/opengraph/developer/graph-data) and [best practices](https://bloodhound.specterops.io/opengraph/developer/best-practices).
 
-If you don't know about BloodHound OpenGraph yet, a great introduction can be found here: [https://bloodhound.specterops.io/opengraph/best-practices](https://bloodhound.specterops.io/opengraph/best-practices)
+If you don't know about BloodHound OpenGraph yet, a great introduction can be found here: [https://bloodhound.specterops.io/opengraph/overview](https://bloodhound.specterops.io/opengraph/overview)
 
 ## Installation
 
@@ -30,7 +30,7 @@ go get github.com/TheManticoreProject/gopengraph
 
 ## Examples
 
-Here is an example of a Go program using the [gopengraph](https://github.com/TheManticoreProject/gopengraph) Go library to model the [Minimal Working JSON](https://bloodhound.specterops.io/opengraph/schema#minimal-working-json) from the OpenGraph Schema documentation:
+Here is an example of a Go program using the [gopengraph](https://github.com/TheManticoreProject/gopengraph) Go library to model the [Minimal Working JSON](https://bloodhound.specterops.io/opengraph/developer/graph-data) from the OpenGraph Schema documentation:
 
 ```go
 package main
@@ -83,7 +83,7 @@ func main() {
 }
 ```
 
-This gives us the following [Minimal Working JSON](https://bloodhound.specterops.io/opengraph/schema#minimal-working-json) as per the documentation:
+This gives us the following [Minimal Working JSON](https://bloodhound.specterops.io/opengraph/developer/graph-data) as per the documentation:
 
 ```json
 {
@@ -142,7 +142,7 @@ Pull requests are welcome. Feel free to open an issue if you want to add other f
 
 ## References
 
-- [BloodHound OpenGraph Best Practices](https://bloodhound.specterops.io/opengraph/best-practices)
-- [BloodHound OpenGraph Schema](https://bloodhound.specterops.io/opengraph/schema)
-- [BloodHound OpenGraph API](https://bloodhound.specterops.io/opengraph/api)
-- [BloodHound OpenGraph Custom Icons](https://bloodhound.specterops.io/opengraph/custom-icons)
+- [BloodHound OpenGraph Best Practices](https://bloodhound.specterops.io/opengraph/developer/best-practices)
+- [BloodHound OpenGraph Schema](https://bloodhound.specterops.io/opengraph/developer/graph-data)
+- [BloodHound OpenGraph API](https://bloodhound.specterops.io/opengraph/developer/api)
+- [BloodHound OpenGraph Custom Icons](https://bloodhound.specterops.io/opengraph/developer/custom-icons)


### PR DESCRIPTION
### Linked Issue
Closes #17

### Summary
Updates references that pointed to the retired `/opengraph/schema`, `/opengraph/best-practices`, `/opengraph/api`, and `/opengraph/custom-icons` documentation paths to their current `/opengraph/developer/...` locations.

### Fix Description
- `README.md`: schema links -> `/opengraph/developer/graph-data`; best-practices -> `/opengraph/developer/best-practices`; the intro "great introduction" link -> `/opengraph/overview`; minimal-working-JSON anchors -> `/opengraph/developer/graph-data`; API -> `/opengraph/developer/api`; custom-icons -> `/opengraph/developer/custom-icons`.
- `OpenGraph.go` header comment: schema/best-practices source links -> `/opengraph/developer/graph-data` and `/opengraph/developer/best-practices`.

### How Verified
- `go build ./...` and `go test ./...` pass.
- `grep` confirms no `/opengraph/schema`, `/opengraph/best-practices`, `/opengraph/api`, or `/opengraph/custom-icons` references remain in the changed files.
- Target paths correspond to live pages listed in the documentation index (https://bloodhound.specterops.io/llms.txt).

### Test Coverage
**None:** documentation/comment-only change; no behavior to test.

### Scope of Change
- **Files changed:** `README.md`, `OpenGraph.go` (comment only)
- **Submodule pointer updated:** no
- **Behavioral changes outside the doc update:** none

### Notes
The `node/Node.go` and `edge/Edge.go` header-comment links are updated within the related PRs #10 and #14 to avoid overlapping edits; this PR deliberately leaves those two files untouched.